### PR TITLE
apiFilter, apiFetch and oHandler

### DIFF
--- a/flow.js
+++ b/flow.js
@@ -481,6 +481,6 @@ declare module 'brewskey.js-api' {
   */
 
   declare type FilterCreators = ({ [string]: any=> QueryFilter });
-  declare function fetch(path: string, init: ?Object): Promise<*>;
-  declare function filter(params: any): FilterCreators;
+  declare function apiFetch(path: string, init: ?Object): Promise<*>;
+  declare function apiFilter(params: any): FilterCreators;
 }

--- a/flow.js
+++ b/flow.js
@@ -476,4 +476,9 @@ declare module 'brewskey.js-api' {
   declare var SrmDAO: brewskey$SrmDAO;
   declare var StyleDAO: brewskey$StyleDAO;
   declare var TapDAO: brewskey$TapDAO;
+
+  /* Utilities
+  */
+
+  declare function fetch(path: string, init: ?Object): Promise<*>;
 }

--- a/flow.js
+++ b/flow.js
@@ -480,5 +480,7 @@ declare module 'brewskey.js-api' {
   /* Utilities
   */
 
+  declare type FilterCreators = ({ [string]: any=> QueryFilter });
   declare function fetch(path: string, init: ?Object): Promise<*>;
+  declare function filter(params: any): FilterCreators;
 }

--- a/flow.js
+++ b/flow.js
@@ -480,7 +480,8 @@ declare module 'brewskey.js-api' {
   /* Utilities
   */
 
+  declare var oHandler: OHandler;
   declare type FilterCreators = ({ [string]: any=> QueryFilter });
-  declare function apiFetch(path: string, init: ?Object): Promise<*>;
   declare function apiFilter(params: any): FilterCreators;
+  declare function apiFetch(path: string, init: ?Object): Promise<*>;
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "eslint-plugin-flowtype": "^2.29.1",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-sorting": "^0.3.0",
-    "flow-bin": "^0.37.0"
+    "flow-bin": "^0.37.1"
   },
   "dependencies": {
     "odata": "^0.3.0"

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -1,0 +1,23 @@
+// @flow
+import oHandler from './handler';
+
+export default (path: string, init: ?Object): Promise<*> => {
+  const {
+    endpoint,
+    headers: oheaders = [],
+  } = oHandler().oConfig;
+
+  if (!endpoint) {
+    throw new Error('no-ohandler-endpoint');
+  }
+
+  const headers = new Headers();
+  oheaders.forEach(({ name, value }: { name: string, value: string }): void =>
+    headers.append(name, value)
+  );
+
+  return fetch(
+    `${endpoint}/${path}`,
+    Object.assign({ headers }, init),
+  );
+};

--- a/src/filters.js
+++ b/src/filters.js
@@ -1,0 +1,37 @@
+// @flow
+import type {
+  FilterCreators,
+  FilterOperator,
+  QueryFilter,
+} from 'brewskey.js-api';
+import { FILTER_OPERATORS } from './constants';
+
+const FILTERS: { [string]: FilterOperator } = {
+  contains: FILTER_OPERATORS.CONTAINS,
+  endsWith: FILTER_OPERATORS.ENDS_WITH,
+  equals: FILTER_OPERATORS.EQUALS,
+  greaterThan: FILTER_OPERATORS.GREATER_THAN,
+  greaterThanOrEqual: FILTER_OPERATORS.GREATER_THAN_OR_EQUAL,
+  lessThan: FILTER_OPERATORS.LESS_THAN,
+  lessThanOrEqual: FILTER_OPERATORS.LESS_THAN_OR_EQUAL,
+  notEndsWith: FILTER_OPERATORS.NOT_ENDS_WITH,
+  notEquals: FILTER_OPERATORS.NOT_EQUALS,
+  notStartsWith: FILTER_OPERATORS.NOT_STARTS_WITH,
+  startsWith: FILTER_OPERATORS.STARTS_WITH,
+};
+
+const makeFilter = (
+  operator: FilterOperator,
+  params: any,
+): (any=> QueryFilter) =>
+  (values: any): QueryFilter => ({
+    operator,
+    params: Array.isArray(params) ? params : [params],
+    values: Array.isArray(values) ? values : [values],
+  });
+
+export default (params: any): FilterCreators => Object.keys(FILTERS).reduce(
+  (filters: FilterCreators, filter: string): FilterCreators =>
+    ({ ...filters, [filter]: makeFilter(FILTERS[filter], params) }),
+  {},
+);

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 // @flow
-export { default as fetch } from './fetch';
-export { default as filter } from './filters';
+export { default as apiFetch } from './fetch';
+export { default as apiFilter } from './filters';
 
 export { default as AccountDAO } from './dao/AccountDAO';
 export { default as AvailabilityDAO } from './dao/AvailabilityDAO';

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,6 @@
 // @flow
+export { default as fetch } from './fetch';
+
 export { default as AccountDAO } from './dao/AccountDAO';
 export { default as AvailabilityDAO } from './dao/AvailabilityDAO';
 export { default as BeverageDAO } from './dao/BeverageDAO';

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 // @flow
 export { default as apiFetch } from './fetch';
 export { default as apiFilter } from './filters';
+export { default as oHandler } from './handler';
 
 export { default as AccountDAO } from './dao/AccountDAO';
 export { default as AvailabilityDAO } from './dao/AvailabilityDAO';

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 // @flow
 export { default as fetch } from './fetch';
+export { default as filter } from './filters';
 
 export { default as AccountDAO } from './dao/AccountDAO';
 export { default as AvailabilityDAO } from './dao/AvailabilityDAO';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1155,9 +1155,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.37.0:
-  version "0.37.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.37.0.tgz#456ebbd472d20d2d970560cea0a6b3c648878307"
+flow-bin@^0.37.1:
+  version "0.37.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.37.1.tgz#ddc3314d18c268ef79efabf14c22870dce4595b3"
 
 for-in@^0.1.5:
   version "0.1.6"


### PR DESCRIPTION
This PR adds the convenience function `apiFilter`, the `apiFetch` that considers the `oHandler` headers and finally exports the internal `oHandler` to be configured from consumer package.