### PR TITLE
Action creators tidy up

### DIFF
--- a/flow.js
+++ b/flow.js
@@ -97,32 +97,6 @@ declare module 'brewskey.js-api' {
     types: RequestStatus,
   };
 
-  declare type ResultSet<TModel> = OHandler<TModel> & {
-    data: Array<TModel>,
-    inlinecount?: number,
-  };
-
-  declare type RequestAction = {
-    method: RequestMethod,
-    type: string,
-  };
-
-  declare type SuccessAction<TModel> = {
-    method: RequestMethod,
-    params?: Object,
-    queryOptions: QueryOptions,
-    result: ResultSet<TModel>,
-    type: string,
-  };
-
-  declare type FailureAction = {
-    error: Error,
-    method: RequestMethod,
-    params?: Object,
-    queryOptions: QueryOptions,
-    type: string,
-  };
-
   declare type ODataChartParams = {
     beginDate?: ?Date,
     endDate?: ?Date,

--- a/flow.js
+++ b/flow.js
@@ -458,4 +458,11 @@ declare module 'brewskey.js-api' {
   declare type FilterCreators = ({ [string]: any=> QueryFilter });
   declare function apiFilter(params: any): FilterCreators;
   declare function apiFetch(path: string, init: ?Object): Promise<*>;
+  declare function createODataAction<TModel>(
+    config: ConfigType<TModel>,
+    types: RequestStatus,
+    queryOptions: QueryOptions,
+    params?: Object,
+    meta?: Object,
+  ): ODataAction<TModel>;
 }

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,13 +1,9 @@
 // @flow
 import type {
   ConfigType,
-  FailureAction,
   QueryOptions,
   ODataAction,
-  ResultSet,
-  RequestAction,
   RequestStatus,
-  SuccessAction,
 } from 'brewskey.js-api';
 
 import { ODATA_API } from './constants';
@@ -33,43 +29,4 @@ const createODataAction = <TModel>(
   return method === 'get' ? oDataAction : { ...oDataAction, params: data };
 };
 
-const createRequestAction = <TModel>(
-  { types, meta, method, params, queryOptions }: ODataAction<TModel>,
-): RequestAction => ({
-  meta,
-  method,
-  params,
-  queryOptions,
-  type: types.REQUEST,
-});
-
-const createSuccessAction = <TModel>(
-  { types, meta, method, params, queryOptions }: ODataAction<TModel>,
-  result: ResultSet<TModel>,
-): SuccessAction<TModel> => ({
-  meta,
-  method,
-  params,
-  queryOptions,
-  result,
-  type: types.SUCCESS,
-});
-
-const createFailureAction = <TModel>(
-  { types, meta, method, params, queryOptions }: ODataAction<TModel>,
-  error: Error,
-): FailureAction => ({
-  error,
-  meta,
-  method,
-  params,
-  queryOptions,
-  type: types.FAILURE,
-});
-
-export {
-  createODataAction,
-  createRequestAction,
-  createSuccessAction,
-  createFailureAction,
-};
+export default createODataAction;

--- a/src/dao/DAO.js
+++ b/src/dao/DAO.js
@@ -15,9 +15,7 @@ import {
   FILTER_FUNCTION_OPERATORS,
 } from '../constants';
 
-import {
-  createODataAction,
-} from '../actions';
+import createODataAction from '../actions';
 
 import oHandler from '../handler';
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 export { default as apiFetch } from './fetch';
 export { default as apiFilter } from './filters';
 export { default as oHandler } from './handler';
+export { default as createODataAction } from './actions';
 
 export { default as AccountDAO } from './dao/AccountDAO';
 export { default as AvailabilityDAO } from './dao/AvailabilityDAO';


### PR DESCRIPTION
Turns out some of the action creators I moved were implementation specific (the DAO doesn't know how the data is fetched, so 'request' 'success' and 'failure' doesn't mean anything). This was obvious since the functions weren't being used by the package, so I just removed them. Also, the `createODataAction` was exported too for convenience.