### PR TITLE
Action to Promise

### DIFF
--- a/flow.js
+++ b/flow.js
@@ -433,7 +433,7 @@ declare module 'brewskey.js-api' {
   declare class brewskey$DeviceDAO extends DAO<Device, Device> {}
   declare class brewskey$GlassDAO extends DAO<Glass, Glass> {}
   declare class brewskey$KegDAO extends DAO<Keg, Keg> {
-    fetchKegByTapID(tapId: string): ODataAction<Keg>;
+    fetchKegByTapID(tapId: string): Promise<DAOResult<Keg>>;
   }
   declare class brewskey$LocationDAO extends DAO<Location, Location> {}
   declare class brewskey$PermissionDAO extends DAO<Permission, PermissionMutator> {}
@@ -441,7 +441,7 @@ declare module 'brewskey.js-api' {
     fetchChartData(
       params: ODataChartParams,
       chartName: string,
-    ): ODataAction<Pour>;
+    ): Promise<DAOResult<Pour>>;
   }
   declare class brewskey$ScheduleDAO extends DAO<Schedule, ScheduleMutator> {}
   declare class brewskey$SrmDAO extends DAO<Srm, Srm> {}

--- a/flow.js
+++ b/flow.js
@@ -402,18 +402,29 @@ declare module 'brewskey.js-api' {
   /* DAO implementation
   */
 
+  declare type ODataResult<TModel> = OHandler<TModel> & {
+    data: Object | Array<Object>,
+    inlinecount?: number,
+  };
+
+  declare type DAOResult<TModel> = {
+    action: ODataAction<TModel>,
+    data: ?(TModel | Array<TModel>),
+    handler: ODataResult<TModel>,
+  };
+
   declare class DAO<TModel, TModelMutator> {
     _config: DAOConfig<TModel, TModelMutator>;
-    count(queryOptions: QueryOptions): ODataAction<TModel>;
-    deleteByID: (id: string) => ODataAction<TModel>;
-    fetchByID(id: string): ODataAction<TModel>;
-    fetchByIDs(ids: Array<string>, meta?: Object): ODataAction<TModel>;
-    fetchMany(queryOptions: QueryOptions): ODataAction<TModel>;
+    count(queryOptions: QueryOptions): Promise<DAOResult<TModel>>;
+    deleteByID(id: string): Promise<DAOResult<TModel>>;
+    fetchByID(id: string): Promise<DAOResult<TModel>>;
+    fetchByIDs(ids: Array<string>, meta?: Object): Promise<DAOResult<TModel>>;
+    fetchMany(queryOptions: QueryOptions): Promise<DAOResult<TModel>>;
     getEntityName(): EntityName;
     getTranslator(): DAOTranslator<TModel, TModelMutator>;
-    patch(id: string, params: TModelMutator): ODataAction<TModel>;
-    post(params: TModelMutator): ODataAction<TModel>;
-    put(id: string, params: TModelMutator): ODataAction<TModel>;
+    patch(id: string, params: TModelMutator): Promise<DAOResult<TModel>>;
+    post(params: TModelMutator): Promise<DAOResult<TModel>>;
+    put(id: string, params: TModelMutator): Promise<DAOResult<TModel>>;
   }
 
   declare class brewskey$AccountDAO extends DAO<Account, Account> {}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brewskey.js-api",
-  "version": "0.1.1",
+  "version": "0.2.0-SNAPSHOT",
   "main": "./build/index.js",
   "repository": "https://github.com/Brewskey/brewskey.js-api.git",
   "author": "Brewskey",

--- a/src/dao/KegDAO.js
+++ b/src/dao/KegDAO.js
@@ -1,5 +1,5 @@
 // @flow
-import type { ODataAction, Keg } from 'brewskey.js-api';
+import type { DAOResult, Keg } from 'brewskey.js-api';
 
 import DefaultTranslator from '../translators/DefaultTranslator';
 import DAO from './DAO';
@@ -21,7 +21,7 @@ class KegDAO extends DAO<Keg, Keg> {
     });
   }
 
-  fetchKegByTapID(tapId: string): ODataAction<Keg> {
+  fetchKegByTapID(tapId: string): Promise<DAOResult<Keg>> {
     const idFilter = {
       operator: FILTER_OPERATORS.EQUALS,
       params: ['tap/id'],
@@ -37,10 +37,10 @@ class KegDAO extends DAO<Keg, Keg> {
       take: 1,
     };
 
-    return this.__query(
+    return this._resolve(this.__query(
       DAO_ACTIONS.FETCH_KEG_BY_TAP_ID,
       queryOptions,
-    );
+    ));
   }
 }
 

--- a/src/dao/PourDAO.js
+++ b/src/dao/PourDAO.js
@@ -1,5 +1,5 @@
 // @flow
-import type { ODataAction, ODataChartParams, Pour } from 'brewskey.js-api';
+import type { DAOResult, ODataChartParams, Pour } from 'brewskey.js-api';
 
 import DAO from './DAO';
 import oHandler from '../handler';
@@ -23,7 +23,7 @@ class PourDAO extends DAO<Pour, Pour> {
   fetchChartData(
     params: ODataChartParams,
     chartName: string,
-  ): ODataAction<Pour> {
+  ): Promise<DAOResult<Pour>> {
     const action = this.__query(
       DAO_ACTIONS.FETCH_CHART_DATA,
       {},
@@ -33,7 +33,7 @@ class PourDAO extends DAO<Pour, Pour> {
 
     action.method = 'post';
     action.oHandler = oHandler('chart');
-    return action;
+    return this._resolve(action);
   }
 }
 


### PR DESCRIPTION
So, this is a non-refactor way of implementing what you both discussed with me.
Like I said to Anton, I'm still not entirely sure how we want this pattern to be, but I took a shot to get things going.

This PR implements a `_resolve` method on the `DAO` that does what it says: take the `ODataAction` and returns a promise of it. It does exactly what the middleware would do. Then I made all methods that returned an `ODataAction` return the resolved version of it.

One important thing: the Promise return resolves to a `DAOResult`, which includes the full `ODataAction`, alongside the untouched API result and the translated data. I figure this was a better pattern than the `data.data = data` with had that modified the API result. This way we can get the raw and the translated, with the translated data being handy.

Anyway, I think it looks good like that.
The only thing I'm still thinking is how to integrate it with redux. I actually have an idea that would let us just dispatch the promises like they were actions with the middleware dispatching this real actions. The thing is for this to work, I have to able to identify the Promise as being a DAO Promise. For that a simple arbitrary prop name on it would suffice, but I wanted to see what you guys think. It'd make the transition almost transparent in `brewskey-admin`.