### PR TITLE
remove nanoid, go back to handlers in subscriptions

### DIFF
--- a/build/dao/BaseDAO.js
+++ b/build/dao/BaseDAO.js
@@ -74,8 +74,6 @@ var BaseDAO = function () {
     value: function __setupHandler(handler) {
       var queryOptions = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
       var shouldSelectExpand = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : true;
-
-      /* eslint-disable no-param-reassign */
       var shouldCount = queryOptions.shouldCount,
           skip = queryOptions.skip,
           take = queryOptions.take;

--- a/build/dao/DAO.js
+++ b/build/dao/DAO.js
@@ -8,10 +8,6 @@ var _extends = Object.assign || function (target) { for (var i = 1; i < argument
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
-var _nanoid = require('nanoid');
-
-var _nanoid2 = _interopRequireDefault(_nanoid);
-
 var _nullthrows = require('nullthrows');
 
 var _nullthrows2 = _interopRequireDefault(_nullthrows);
@@ -46,7 +42,7 @@ var DAO = function (_BaseDAO) {
       args[_key] = arguments[_key];
     }
 
-    return _ret = (_temp = (_temp2 = (_this = _possibleConstructorReturn(this, (_ref = DAO.__proto__ || Object.getPrototypeOf(DAO)).call.apply(_ref, [this].concat(args))), _this), _this.deleteByID = _this.deleteByID.bind(_this), _this.count = _this.count.bind(_this), _this.fetchByID = _this.fetchByID.bind(_this), _this.fetchByIDs = _this.fetchByIDs.bind(_this), _this.fetchMany = _this.fetchMany.bind(_this), _this.flushCache = _this.flushCache.bind(_this), _this.patch = _this.patch.bind(_this), _this.post = _this.post.bind(_this), _this.put = _this.put.bind(_this), _this.subscribe = _this.subscribe.bind(_this), _this.unsubscribe = _this.unsubscribe.bind(_this), _this._emitChanges = _this._emitChanges.bind(_this), _this._clearQueryCaches = _this._clearQueryCaches.bind(_this), _this._getCacheKey = _this._getCacheKey.bind(_this), _this._updateCacheForEntity = _this._updateCacheForEntity.bind(_this), _this._updateCacheForError = _this._updateCacheForError.bind(_this), _temp2), _this._countLoaderByQuery = new Map(), _this._entityIDsLoaderByQuery = new Map(), _this._entityLoaderByID = new Map(), _this._subscriptionsByID = new Map(), _temp), _possibleConstructorReturn(_this, _ret);
+    return _ret = (_temp = (_temp2 = (_this = _possibleConstructorReturn(this, (_ref = DAO.__proto__ || Object.getPrototypeOf(DAO)).call.apply(_ref, [this].concat(args))), _this), _this.deleteByID = _this.deleteByID.bind(_this), _this.count = _this.count.bind(_this), _this.fetchByID = _this.fetchByID.bind(_this), _this.fetchByIDs = _this.fetchByIDs.bind(_this), _this.fetchMany = _this.fetchMany.bind(_this), _this.flushCache = _this.flushCache.bind(_this), _this.patch = _this.patch.bind(_this), _this.post = _this.post.bind(_this), _this.put = _this.put.bind(_this), _this.subscribe = _this.subscribe.bind(_this), _this.unsubscribe = _this.unsubscribe.bind(_this), _this._emitChanges = _this._emitChanges.bind(_this), _this._clearQueryCaches = _this._clearQueryCaches.bind(_this), _this._getCacheKey = _this._getCacheKey.bind(_this), _this._updateCacheForEntity = _this._updateCacheForEntity.bind(_this), _this._updateCacheForError = _this._updateCacheForError.bind(_this), _temp2), _this._countLoaderByQuery = new Map(), _this._entityIDsLoaderByQuery = new Map(), _this._entityLoaderByID = new Map(), _this._subscriptions = new Set(), _temp), _possibleConstructorReturn(_this, _ret);
   }
 
   _createClass(DAO, [{
@@ -243,19 +239,17 @@ var DAO = function (_BaseDAO) {
   }, {
     key: 'subscribe',
     value: function subscribe(handler) {
-      var subscriptionID = (0, _nanoid2.default)();
-      this._subscriptionsByID.set(subscriptionID, handler);
-      return subscriptionID;
+      this._subscriptions.add(handler);
     }
   }, {
     key: 'unsubscribe',
-    value: function unsubscribe(subscriptionID) {
-      this._subscriptionsByID.delete(subscriptionID);
+    value: function unsubscribe(handler) {
+      this._subscriptions.delete(handler);
     }
   }, {
     key: '_emitChanges',
     value: function _emitChanges() {
-      this._subscriptionsByID.forEach(function (handler) {
+      this._subscriptions.forEach(function (handler) {
         return handler();
       });
     }

--- a/build/index.js.flow
+++ b/build/index.js.flow
@@ -500,8 +500,8 @@ declare export class DAO<
   patch(id: EntityID, params: TEntityMutator): void;
   post(params: TEntityMutator): void;
   put(id: EntityID, params: TEntityMutator): void;
-  subscribe(handler: () => void): string;
-  unsubscribe(subscriptionID: string): void;
+  subscribe(handler: () => void): void;
+  unsubscribe(handler: () => void): void;
 }
 
 declare class brewskey$AccountDAO extends DAO<Account, AccountMutator> {}

--- a/package.json
+++ b/package.json
@@ -4,9 +4,7 @@
   "main": "./build/index.js",
   "repository": "https://github.com/Brewskey/brewskey.js-api.git",
   "author": "Brewskey",
-  "files": [
-    "build/"
-  ],
+  "files": ["build/"],
   "scripts": {
     "build": "babel src -d build --copy-files",
     "flow": "flow",
@@ -42,15 +40,10 @@
   },
   "dependencies": {
     "babel-preset-react-hmre": "^1.1.1",
-    "nanoid": "^1.0.1",
     "nullthrows": "^1.0.0",
     "odata": "git+https://github.com/Brewskey/o.js.git"
   },
   "lint-staged": {
-    "src/**/*.{js,json}": [
-      "prettier --write",
-      "lint",
-      "git add"
-    ]
+    "src/**/*.{js,json}": ["prettier --write", "lint", "git add"]
   }
 }

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -500,8 +500,8 @@ declare export class DAO<
   patch(id: EntityID, params: TEntityMutator): void;
   post(params: TEntityMutator): void;
   put(id: EntityID, params: TEntityMutator): void;
-  subscribe(handler: () => void): string;
-  unsubscribe(subscriptionID: string): void;
+  subscribe(handler: () => void): void;
+  unsubscribe(handler: () => void): void;
 }
 
 declare class brewskey$AccountDAO extends DAO<Account, AccountMutator> {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -770,8 +770,8 @@ callsites@^0.2.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
 
 caniuse-lite@^1.0.30000760:
-  version "1.0.30000760"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000760.tgz#ec720395742f1c7ec8947fd6dd2604e77a8f98ff"
+  version "1.0.30000766"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000766.tgz#8a095cc5eb9923c27008ce4d0db23e65a3e28843"
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -2139,12 +2139,8 @@ mute-stream@0.0.5:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
 
 nan@^2.3.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.7.0.tgz#d95bf721ec877e08db276ed3fc6eb78f9083ad46"
-
-nanoid@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-1.0.1.tgz#58a8e0577d9db07ae4f231a3afa59af94e4fc439"
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.8.0.tgz#ed715f3fe9de02b57a5e6252d90a96675e1f085a"
 
 natural-compare@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
It could be a little bit cleaner to operate subscriptionID instead of handlers but turns out react-native doesn't support `crypto` out of the box, so libs like nanoid or uuid don't work in that env. There are some workarounds like rn-nodeify but nah, callbacks are fine here.